### PR TITLE
Fix bug in CMakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,5 @@ link_directories(${TANGO_PKG_LIBRARY_DIRS})
 
 add_executable(${PROJECT_NAME} ${SOURCES} ${HEADERS})
 target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} ${TANGO_PKG_INCLUDE_DIRS})
-target_compile_options(${PROJECT_NAME} PUBLIC -std=c++11)
-target_compile_definitions(${PROJECT_NAME} PUBLIC ${TANGO_PKG_CFLAGS_OTHER})
+target_compile_options(${PROJECT_NAME} PUBLIC -std=c++11 ${TANGO_PKG_CFLAGS_OTHER})
 target_link_libraries(${PROJECT_NAME} PUBLIC ${TANGO_PKG_LIBRARIES})


### PR DESCRIPTION
 Pass TANGO_PKG_CFLAGS_OTHER as target options

Correct misused TANGO_PKG_CFLAGS_OTHER
and pass it as target compile options instead of definitions