### PR TITLE
Fix compilation without "using namespace std"

### DIFF
--- a/TangoTest.cpp
+++ b/TangoTest.cpp
@@ -188,13 +188,13 @@ public:
 
   void go (void)
   {
-    DEBUG_STREAM << "DataGenerator::go" << endl;
+    DEBUG_STREAM << "DataGenerator::go" << std::endl;
     start_undetached();
   }
 
   void crash (void)
   {
-    WARN_STREAM << "DataGenerator::crash" << endl;
+    WARN_STREAM << "DataGenerator::crash" << std::endl;
     generate_crash_ = true;
   }
 
@@ -202,7 +202,7 @@ public:
   {
     static int * __invalid_ptr__ = 0;
 
-    DEBUG_STREAM << "DataGenerator::run_undetached" << endl;
+    DEBUG_STREAM << "DataGenerator::run_undetached" << std::endl;
     do
     {
       if (generate_crash_)
@@ -211,7 +211,7 @@ public:
       { //- enter critical section
         omni_mutex_lock guard(dev_.lock);
         if (! go_on_) break;
-        DEBUG_STREAM << "DataGenerator::generating data" << endl;
+        DEBUG_STREAM << "DataGenerator::generating data" << std::endl;
         dev_.gen_data();
       } //- leave critical section
       sleep(0, sleep_time_ * 1000000);
@@ -222,7 +222,7 @@ public:
 
   void abort (void)
   {
-    DEBUG_STREAM << "DataGenerator::abort" << endl;
+    DEBUG_STREAM << "DataGenerator::abort" << std::endl;
     go_on_ = 0;
   }
 
@@ -997,9 +997,9 @@ void TangoTest::get_device_property()
 	/*----- PROTECTED REGION ID(TangoTest::get_device_property_after) ENABLED START -----*/
 
 	//	Check device property data members init
-	DEBUG_STREAM << "sleep_period=" << sleep_period << endl;
-	DEBUG_STREAM << "mthreaded_impl=" << mthreaded_impl << endl;
-	DEBUG_STREAM << "uShort_image_ro_size=" << uShort_image_ro_size << endl;
+	DEBUG_STREAM << "sleep_period=" << sleep_period << std::endl;
+	DEBUG_STREAM << "mthreaded_impl=" << mthreaded_impl << std::endl;
+	DEBUG_STREAM << "uShort_image_ro_size=" << uShort_image_ro_size << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::get_device_property_after
 }
@@ -1073,7 +1073,7 @@ void TangoTest::write_ampli(Tango::WAttribute &attr)
 	Tango::DevDouble	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_ampli) ENABLED START -----*/
-  	DEBUG_STREAM << "ampli = " << w_val << endl;
+  	DEBUG_STREAM << "ampli = " << w_val << std::endl;
 	attr_ampli_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_ampli
@@ -1113,9 +1113,9 @@ void TangoTest::write_boolean_scalar(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_boolean_scalar) ENABLED START -----*/
 	*attr_boolean_scalar_read = w_val;
 	attr_boolean_scalar_write = w_val;
-	DEBUG_STREAM << "Read and write attributes were set to the same value" << endl;
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
-	DEBUG_STREAM << "attr_boolean_scalar_read = " << *attr_boolean_scalar_read << endl;
+	DEBUG_STREAM << "Read and write attributes were set to the same value" << std::endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
+	DEBUG_STREAM << "attr_boolean_scalar_read = " << *attr_boolean_scalar_read << std::endl;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_boolean_scalar
 }
@@ -1152,7 +1152,7 @@ void TangoTest::write_double_scalar(Tango::WAttribute &attr)
 	Tango::DevDouble	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_double_scalar) ENABLED START -----*/
-    DEBUG_STREAM << "w_val = " << w_val << endl;
+    DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_double_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_double_scalar
@@ -1209,7 +1209,7 @@ void TangoTest::write_double_scalar_w(Tango::WAttribute &attr)
 	Tango::DevDouble	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_double_scalar_w) ENABLED START -----*/
-  	DEBUG_STREAM << "double_scalar_w = " << w_val << endl;
+  	DEBUG_STREAM << "double_scalar_w = " << w_val << std::endl;
 	attr_double_scalar_w_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_double_scalar_w
@@ -1247,7 +1247,7 @@ void TangoTest::write_float_scalar(Tango::WAttribute &attr)
 	Tango::DevFloat	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_float_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_float_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_float_scalar
@@ -1285,7 +1285,7 @@ void TangoTest::write_long64_scalar(Tango::WAttribute &attr)
 	Tango::DevLong64	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_long64_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_long64_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_long64_scalar
@@ -1323,7 +1323,7 @@ void TangoTest::write_long_scalar(Tango::WAttribute &attr)
 	Tango::DevLong	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_long_scalar) ENABLED START -----*/
-    DEBUG_STREAM << "w_val = " << w_val << endl;
+    DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_long_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_long_scalar
@@ -1380,7 +1380,7 @@ void TangoTest::write_long_scalar_w(Tango::WAttribute &attr)
 	Tango::DevLong	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_long_scalar_w) ENABLED START -----*/
-  	DEBUG_STREAM << "long_scalar_w = " << w_val << endl;
+  	DEBUG_STREAM << "long_scalar_w = " << w_val << std::endl;
 	attr_long_scalar_w_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_long_scalar_w
@@ -1434,7 +1434,7 @@ void TangoTest::write_short_scalar(Tango::WAttribute &attr)
 	Tango::DevShort	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_short_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_short_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_short_scalar
@@ -1508,7 +1508,7 @@ void TangoTest::write_short_scalar_w(Tango::WAttribute &attr)
 	Tango::DevShort	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_short_scalar_w) ENABLED START -----*/
-  	DEBUG_STREAM << "short_scalar_w = " << w_val << endl;
+  	DEBUG_STREAM << "short_scalar_w = " << w_val << std::endl;
 	attr_short_scalar_w_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_short_scalar_w
@@ -1546,7 +1546,7 @@ void TangoTest::write_string_scalar(Tango::WAttribute &attr)
 	Tango::DevString	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_string_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_string_scalar_write = w_val;
   	if (*attr_string_scalar_read)
   	{
@@ -1613,7 +1613,7 @@ void TangoTest::write_uchar_scalar(Tango::WAttribute &attr)
 	Tango::DevUChar	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_uchar_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_uchar_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_uchar_scalar
@@ -1651,7 +1651,7 @@ void TangoTest::write_ulong64_scalar(Tango::WAttribute &attr)
 	Tango::DevULong64	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_ulong64_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_ulong64_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_ulong64_scalar
@@ -1689,7 +1689,7 @@ void TangoTest::write_ushort_scalar(Tango::WAttribute &attr)
 	Tango::DevUShort	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_ushort_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_ushort_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_ushort_scalar
@@ -1727,7 +1727,7 @@ void TangoTest::write_ulong_scalar(Tango::WAttribute &attr)
 	Tango::DevULong	w_val;
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_ulong_scalar) ENABLED START -----*/
-  	DEBUG_STREAM << "w_val = " << w_val << endl;
+  	DEBUG_STREAM << "w_val = " << w_val << std::endl;
 	attr_ulong_scalar_write = w_val;
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::write_ulong_scalar
@@ -1770,7 +1770,7 @@ void TangoTest::write_boolean_spectrum(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_boolean_spectrum) ENABLED START -----*/
 
   long len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length :" << len << endl;
+  DEBUG_STREAM << "Length :" << len << std::endl;
 
   len = (len <= kSpecLen) ? len : kSpecLen;
 
@@ -1835,7 +1835,7 @@ void TangoTest::write_double_spectrum(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_double_spectrum) ENABLED START -----*/
 
   long len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length :" << len << endl;
+  DEBUG_STREAM << "Length :" << len << std::endl;
 
   len = (len <= kSpecLen) ? len : kSpecLen;
 
@@ -1900,7 +1900,7 @@ void TangoTest::write_float_spectrum(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_float_spectrum) ENABLED START -----*/
 
   long len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length :" << len << endl;
+  DEBUG_STREAM << "Length :" << len << std::endl;
 
   len = (len <= kSpecLen) ? len : kSpecLen;
 
@@ -1982,7 +1982,7 @@ void TangoTest::write_long_spectrum(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_long_spectrum) ENABLED START -----*/
 
   long len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length :" << len << endl;
+  DEBUG_STREAM << "Length :" << len << std::endl;
 
   len = (len <= kSpecLen) ? len : kSpecLen;
 
@@ -2046,14 +2046,14 @@ void TangoTest::write_short_spectrum(Tango::WAttribute &attr)
 	attr.get_write_value(w_val);
 	/*----- PROTECTED REGION ID(TangoTest::write_short_spectrum) ENABLED START -----*/
 	long len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length :" << len << endl;
+  DEBUG_STREAM << "Length :" << len << std::endl;
 
   len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length from get_write_value_length:" << len << endl;
+  DEBUG_STREAM << "Length from get_write_value_length:" << len << std::endl;
 
   len = (len <= kSpecLen) ? len : kSpecLen;
 
-  DEBUG_STREAM << "Final length:" << len << endl;
+  DEBUG_STREAM << "Final length:" << len << std::endl;
 
   ::memcpy(attr_short_spectrum_read, w_val, len * sizeof(Tango::DevShort));
   dimShortSpectrum = len;
@@ -2186,7 +2186,7 @@ void TangoTest::write_uchar_spectrum(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_uchar_spectrum) ENABLED START -----*/
 	
   long len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length :" << len << endl;
+  DEBUG_STREAM << "Length :" << len << std::endl;
 
   len = (len <= kSpecLen) ? len : kSpecLen;
 
@@ -2285,7 +2285,7 @@ void TangoTest::write_ushort_spectrum(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_ushort_spectrum) ENABLED START -----*/
 
   long len = attr.get_write_value_length();
-  DEBUG_STREAM << "Length :" << len << endl;
+  DEBUG_STREAM << "Length :" << len << std::endl;
 
   len = (len <= kSpecLen) ? len : kSpecLen;
 
@@ -2367,10 +2367,10 @@ void TangoTest::write_boolean_image(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_boolean_image) ENABLED START -----*/
 
   dimXBooleanImage = attr.get_w_dim_x();
-  DEBUG_STREAM << "X :" << dimXBooleanImage << endl;
+  DEBUG_STREAM << "X :" << dimXBooleanImage << std::endl;
 
   dimYBooleanImage = attr.get_w_dim_y();
-  DEBUG_STREAM << "Y :" << dimYBooleanImage << endl;
+  DEBUG_STREAM << "Y :" << dimYBooleanImage << std::endl;
 
   long len = dimXBooleanImage * dimYBooleanImage;
 
@@ -2438,10 +2438,10 @@ void TangoTest::write_double_image(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_double_image) ENABLED START -----*/
 
   dimXDoubleImage = attr.get_w_dim_x();
-  DEBUG_STREAM << "X :" << dimXDoubleImage << endl;
+  DEBUG_STREAM << "X :" << dimXDoubleImage << std::endl;
 
   dimYDoubleImage = attr.get_w_dim_y();
-  DEBUG_STREAM << "Y :" << dimYDoubleImage << endl;
+  DEBUG_STREAM << "Y :" << dimYDoubleImage << std::endl;
 
   long len = dimXDoubleImage * dimYDoubleImage;
 
@@ -2509,10 +2509,10 @@ void TangoTest::write_float_image(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_float_image) ENABLED START -----*/
 
   dimXFloatImage = attr.get_w_dim_x();
-  DEBUG_STREAM << "X :" << dimXFloatImage << endl;
+  DEBUG_STREAM << "X :" << dimXFloatImage << std::endl;
 
   dimYFloatImage = attr.get_w_dim_y();
-  DEBUG_STREAM << "Y :" << dimYFloatImage << endl;
+  DEBUG_STREAM << "Y :" << dimYFloatImage << std::endl;
 
   long len = dimXFloatImage * dimYFloatImage;
 
@@ -2602,10 +2602,10 @@ void TangoTest::write_long_image(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_long_image) ENABLED START -----*/
 
   dimXLongImage = attr.get_w_dim_x();
-  DEBUG_STREAM << "X :" << dimXLongImage << endl;
+  DEBUG_STREAM << "X :" << dimXLongImage << std::endl;
 
   dimYLongImage = attr.get_w_dim_y();
-  DEBUG_STREAM << "Y :" << dimYLongImage << endl;
+  DEBUG_STREAM << "Y :" << dimYLongImage << std::endl;
 
   long len = dimXLongImage * dimYLongImage;
 
@@ -2673,10 +2673,10 @@ void TangoTest::write_short_image(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_short_image) ENABLED START -----*/
 
   dimXShortImage = attr.get_w_dim_x();
-  DEBUG_STREAM << "X :" << dimXShortImage << endl;
+  DEBUG_STREAM << "X :" << dimXShortImage << std::endl;
 
   dimYShortImage = attr.get_w_dim_y();
-  DEBUG_STREAM << "Y :" << dimYShortImage << endl;
+  DEBUG_STREAM << "Y :" << dimYShortImage << std::endl;
 
   long len = dimXShortImage * dimYShortImage;
 
@@ -2746,12 +2746,12 @@ void TangoTest::write_string_image(Tango::WAttribute &attr)
   dimXStringImage = attr.get_w_dim_x();
   if (dimXStringImage > kImagLen)
     dimXStringImage = kImagLen;
-  DEBUG_STREAM << "X :" << dimXStringImage << endl;
+  DEBUG_STREAM << "X :" << dimXStringImage << std::endl;
 
   dimYStringImage = attr.get_w_dim_y();
   if (dimYStringImage > kImagLen)
     dimYStringImage = kImagLen;
-  DEBUG_STREAM << "Y :" << dimYStringImage << endl;
+  DEBUG_STREAM << "Y :" << dimYStringImage << std::endl;
 
   int i ,j, str_index;
   for (j = 0; j < dimYStringImage; j++)
@@ -2821,10 +2821,10 @@ void TangoTest::write_uchar_image(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_uchar_image) ENABLED START -----*/
 
   dimXUcharImage = attr.get_w_dim_x();
-  DEBUG_STREAM << "X :" << dimXUcharImage << endl;
+  DEBUG_STREAM << "X :" << dimXUcharImage << std::endl;
 
   dimYUcharImage = attr.get_w_dim_y();
-  DEBUG_STREAM << "Y :" << dimYUcharImage << endl;
+  DEBUG_STREAM << "Y :" << dimYUcharImage << std::endl;
 
   long len = dimXUcharImage * dimYUcharImage;
 
@@ -2932,10 +2932,10 @@ void TangoTest::write_ushort_image(Tango::WAttribute &attr)
 	/*----- PROTECTED REGION ID(TangoTest::write_ushort_image) ENABLED START -----*/
 
   dimXUshortImage = attr.get_w_dim_x();
-  DEBUG_STREAM << "X :" << dimXUshortImage << endl;
+  DEBUG_STREAM << "X :" << dimXUshortImage << std::endl;
 
   dimYUshortImage = attr.get_w_dim_y();
-  DEBUG_STREAM << "Y :" << dimYUshortImage << endl;
+  DEBUG_STREAM << "Y :" << dimYUshortImage << std::endl;
 
   long len = dimXUshortImage * dimYUshortImage;
 
@@ -2993,7 +2993,7 @@ void TangoTest::read_string_long_short_ro(Tango::Pipe &pipe)
 	DEBUG_STREAM << "TangoTest::read_string_long_short_ro(Tango::Pipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_string_long_short_ro) ENABLED START -----*/
 
-    vector<string> de_names;
+    std::vector<std::string> de_names;
     de_names.push_back("FirstDE");
     de_names.push_back("SecondDE");
     de_names.push_back("ThirdDE");
@@ -3205,7 +3205,7 @@ Tango::DevString TangoTest::dev_string(Tango::DevString argin)
   argout = new char [::strlen(argin) + 1];
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevString" << ends;
+    o << "Failed to allocate Tango::DevString" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3303,7 +3303,7 @@ Tango::DevVarCharArray *TangoTest::dev_var_char_array(const Tango::DevVarCharArr
 	argout = new Tango::DevVarCharArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarCharArray" << ends;
+    o << "Failed to allocate Tango::DevVarCharArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3343,7 +3343,7 @@ Tango::DevVarDoubleArray *TangoTest::dev_var_double_array(const Tango::DevVarDou
 	argout = new Tango::DevVarDoubleArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarDoubleArray" << ends;
+    o << "Failed to allocate Tango::DevVarDoubleArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3383,7 +3383,7 @@ Tango::DevVarDoubleStringArray *TangoTest::dev_var_double_string_array(const Tan
   argout = new Tango::DevVarDoubleStringArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarDoubleStringArray" << ends;
+    o << "Failed to allocate Tango::DevVarDoubleStringArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3424,7 +3424,7 @@ Tango::DevVarFloatArray *TangoTest::dev_var_float_array(const Tango::DevVarFloat
 	argout = new Tango::DevVarFloatArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarFloatArray" << ends;
+    o << "Failed to allocate Tango::DevVarFloatArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3465,7 +3465,7 @@ Tango::DevVarLong64Array *TangoTest::dev_var_long64_array(const Tango::DevVarLon
   if (argout == 0)
   {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarLong64Array" << ends;
+    o << "Failed to allocate Tango::DevVarLong64Array" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
                                    o.str(),
@@ -3504,7 +3504,7 @@ Tango::DevVarLongArray *TangoTest::dev_var_long_array(const Tango::DevVarLongArr
   argout = new Tango::DevVarLongArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarLongArray" << ends;
+    o << "Failed to allocate Tango::DevVarLongArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3544,7 +3544,7 @@ Tango::DevVarLongStringArray *TangoTest::dev_var_long_string_array(const Tango::
 	argout = new Tango::DevVarLongStringArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarLongStringArray" << ends;
+    o << "Failed to allocate Tango::DevVarLongStringArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3585,7 +3585,7 @@ Tango::DevVarShortArray *TangoTest::dev_var_short_array(const Tango::DevVarShort
   argout = new Tango::DevVarShortArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarShortArray" << ends;
+    o << "Failed to allocate Tango::DevVarShortArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3625,7 +3625,7 @@ Tango::DevVarStringArray *TangoTest::dev_var_string_array(const Tango::DevVarStr
 	argout = new Tango::DevVarStringArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarStringArray" << ends;
+    o << "Failed to allocate Tango::DevVarStringArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3666,7 +3666,7 @@ Tango::DevVarULong64Array *TangoTest::dev_var_ulong64_array(const Tango::DevVarU
   if (argout == 0)
   {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarULong64Array" << ends;
+    o << "Failed to allocate Tango::DevVarULong64Array" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
                                    o.str(),
@@ -3705,7 +3705,7 @@ Tango::DevVarULongArray *TangoTest::dev_var_ulong_array(const Tango::DevVarULong
 	argout = new Tango::DevVarULongArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarULongArray" << ends;
+    o << "Failed to allocate Tango::DevVarULongArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),
@@ -3745,7 +3745,7 @@ Tango::DevVarUShortArray *TangoTest::dev_var_ushort_array(const Tango::DevVarUSh
 	argout = new Tango::DevVarUShortArray();
   if (argout == 0) {
     TangoSys_OMemStream o;
-    o << "Failed to allocate Tango::DevVarUShortArray" << ends;
+    o << "Failed to allocate Tango::DevVarUShortArray" << std::ends;
     LOG_ERROR((o.str()));
     Tango::Except::throw_exception((const char *)"Out of memory error",
 						                       o.str(),

--- a/TangoTest.cpp
+++ b/TangoTest.cpp
@@ -249,7 +249,7 @@ private:
  *                implementing the classTangoTest
  */
 //--------------------------------------------------------
-TangoTest::TangoTest(Tango::DeviceClass *cl, string &s)
+TangoTest::TangoTest(Tango::DeviceClass *cl, std::string &s)
  : TANGO_BASE_CLASS(cl, s.c_str())
 {
 	/*----- PROTECTED REGION ID(TangoTest::constructor_1) ENABLED START -----*/
@@ -284,7 +284,7 @@ TangoTest::TangoTest(Tango::DeviceClass *cl, const char *s, const char *d)
 //--------------------------------------------------------
 void TangoTest::delete_device()
 {
-	DEBUG_STREAM << "TangoTest::delete_device() " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::delete_device() " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::delete_device) ENABLED START -----*/
 
 	//	Delete device allocated objects
@@ -601,7 +601,7 @@ void TangoTest::delete_device()
 //--------------------------------------------------------
 void TangoTest::init_device()
 {
-	DEBUG_STREAM << "TangoTest::init_device() create device " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::init_device() create device " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::init_device_before) ENABLED START -----*/
 
 	//	Initialization before get_device_property() call
@@ -620,11 +620,11 @@ void TangoTest::init_device()
 
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::init_device_before
-
+	
 
 	//	Get the device properties from database
 	get_device_property();
-
+	
 	/*----- PROTECTED REGION ID(TangoTest::init_device) ENABLED START -----*/
 
 	//	Initialize device
@@ -952,7 +952,7 @@ void TangoTest::get_device_property()
 		//	Call database and extract values
 		if (Tango::Util::instance()->_UseDb==true)
 			get_db_device()->get_property(dev_prop);
-
+	
 		//	get instance on TangoTestClass to get class property
 		Tango::DbDatum	def_prop, cl_prop;
 		TangoTestClass	*ds_class =
@@ -1012,7 +1012,7 @@ void TangoTest::get_device_property()
 //--------------------------------------------------------
 void TangoTest::always_executed_hook()
 {
-	DEBUG_STREAM << "TangoTest::always_executed_hook()  " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::always_executed_hook()  " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::always_executed_hook) ENABLED START -----*/
 
 	//	code always executed before all requests
@@ -1026,9 +1026,9 @@ void TangoTest::always_executed_hook()
  *	Description : Hardware acquisition for attributes
  */
 //--------------------------------------------------------
-void TangoTest::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+void TangoTest::read_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "TangoTest::read_attr_hardware(vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_attr_hardware) ENABLED START -----*/
 
 	//	Add your own code
@@ -1047,9 +1047,9 @@ void TangoTest::read_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
  *	Description : Hardware writing for attributes
  */
 //--------------------------------------------------------
-void TangoTest::write_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
+void TangoTest::write_attr_hardware(TANGO_UNUSED(std::vector<long> &attr_list))
 {
-	DEBUG_STREAM << "TangoTest::write_attr_hardware(vector<long> &attr_list) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_attr_hardware(std::vector<long> &attr_list) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::write_attr_hardware) ENABLED START -----*/
 
 	//	Add your own code
@@ -1060,7 +1060,7 @@ void TangoTest::write_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
 //--------------------------------------------------------
 /**
  *	Write attribute ampli related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -1068,7 +1068,7 @@ void TangoTest::write_attr_hardware(TANGO_UNUSED(vector<long> &attr_list))
 //--------------------------------------------------------
 void TangoTest::write_ampli(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_ampli(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_ampli(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevDouble	w_val;
 	attr.get_write_value(w_val);
@@ -1089,7 +1089,7 @@ void TangoTest::write_ampli(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_boolean_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_boolean_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_boolean_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_boolean_scalar) ENABLED START -----*/
 	attr.set_value(attr_boolean_scalar_read);
 
@@ -1106,7 +1106,7 @@ void TangoTest::read_boolean_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_boolean_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_boolean_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_boolean_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevBoolean	w_val;
 	attr.get_write_value(w_val);
@@ -1122,7 +1122,7 @@ void TangoTest::write_boolean_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute double_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -1130,7 +1130,7 @@ void TangoTest::write_boolean_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_double_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_double_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_double_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_double_scalar) ENABLED START -----*/
 	attr.set_value(attr_double_scalar_read);
 
@@ -1139,7 +1139,7 @@ void TangoTest::read_double_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute double_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -1147,7 +1147,7 @@ void TangoTest::read_double_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_double_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_double_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_double_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevDouble	w_val;
 	attr.get_write_value(w_val);
@@ -1160,7 +1160,7 @@ void TangoTest::write_double_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute double_scalar_rww related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -1168,7 +1168,7 @@ void TangoTest::write_double_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_double_scalar_rww(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_double_scalar_rww(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_double_scalar_rww(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_double_scalar_rww) ENABLED START -----*/
 	attr.set_value(attr_double_scalar_rww_read);
 
@@ -1177,7 +1177,7 @@ void TangoTest::read_double_scalar_rww(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute double_scalar_rww related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -1185,7 +1185,7 @@ void TangoTest::read_double_scalar_rww(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_double_scalar_rww(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_double_scalar_rww(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_double_scalar_rww(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevDouble	w_val;
 	attr.get_write_value(w_val);
@@ -1196,7 +1196,7 @@ void TangoTest::write_double_scalar_rww(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute double_scalar_w related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -1204,7 +1204,7 @@ void TangoTest::write_double_scalar_rww(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_double_scalar_w(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_double_scalar_w(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_double_scalar_w(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevDouble	w_val;
 	attr.get_write_value(w_val);
@@ -1225,7 +1225,7 @@ void TangoTest::write_double_scalar_w(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_float_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_float_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_float_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_float_scalar) ENABLED START -----*/
 	attr.set_value(attr_float_scalar_read);
 
@@ -1242,7 +1242,7 @@ void TangoTest::read_float_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_float_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_float_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_float_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevFloat	w_val;
 	attr.get_write_value(w_val);
@@ -1255,7 +1255,7 @@ void TangoTest::write_float_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long64_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong64
  *	Attr type:	Scalar
@@ -1263,7 +1263,7 @@ void TangoTest::write_float_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long64_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long64_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long64_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long64_scalar) ENABLED START -----*/
 	attr.set_value(attr_long64_scalar_read);
 
@@ -1272,7 +1272,7 @@ void TangoTest::read_long64_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute long64_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong64
  *	Attr type:	Scalar
@@ -1280,7 +1280,7 @@ void TangoTest::read_long64_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_long64_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_long64_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_long64_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevLong64	w_val;
 	attr.get_write_value(w_val);
@@ -1293,7 +1293,7 @@ void TangoTest::write_long64_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -1301,7 +1301,7 @@ void TangoTest::write_long64_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long_scalar) ENABLED START -----*/
 	attr.set_value(attr_long_scalar_read);
 
@@ -1310,7 +1310,7 @@ void TangoTest::read_long_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute long_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -1318,7 +1318,7 @@ void TangoTest::read_long_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_long_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_long_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_long_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevLong	w_val;
 	attr.get_write_value(w_val);
@@ -1331,7 +1331,7 @@ void TangoTest::write_long_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long_scalar_rww related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -1339,7 +1339,7 @@ void TangoTest::write_long_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long_scalar_rww(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long_scalar_rww(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long_scalar_rww(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long_scalar_rww) ENABLED START -----*/
 	attr.set_value(attr_long_scalar_rww_read);
 
@@ -1348,7 +1348,7 @@ void TangoTest::read_long_scalar_rww(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute long_scalar_rww related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -1356,7 +1356,7 @@ void TangoTest::read_long_scalar_rww(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_long_scalar_rww(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_long_scalar_rww(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_long_scalar_rww(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevLong	w_val;
 	attr.get_write_value(w_val);
@@ -1367,7 +1367,7 @@ void TangoTest::write_long_scalar_rww(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute long_scalar_w related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -1375,7 +1375,7 @@ void TangoTest::write_long_scalar_rww(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_long_scalar_w(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_long_scalar_w(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_long_scalar_w(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevLong	w_val;
 	attr.get_write_value(w_val);
@@ -1388,7 +1388,7 @@ void TangoTest::write_long_scalar_w(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute no_value related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -1396,7 +1396,7 @@ void TangoTest::write_long_scalar_w(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_no_value(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_no_value(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_no_value(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_no_value) ENABLED START -----*/
 
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::read_no_value
@@ -1404,7 +1404,7 @@ void TangoTest::read_no_value(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute short_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -1412,7 +1412,7 @@ void TangoTest::read_no_value(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_short_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_short_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_short_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_short_scalar) ENABLED START -----*/
 	attr.set_value(attr_short_scalar_read);
 
@@ -1421,7 +1421,7 @@ void TangoTest::read_short_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute short_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -1429,7 +1429,7 @@ void TangoTest::read_short_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_short_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_short_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_short_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevShort	w_val;
 	attr.get_write_value(w_val);
@@ -1442,7 +1442,7 @@ void TangoTest::write_short_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute short_scalar_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -1450,7 +1450,7 @@ void TangoTest::write_short_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_short_scalar_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_short_scalar_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_short_scalar_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_short_scalar_ro) ENABLED START -----*/
 	attr.set_value(attr_short_scalar_ro_read);
 
@@ -1459,7 +1459,7 @@ void TangoTest::read_short_scalar_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute short_scalar_rww related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -1467,7 +1467,7 @@ void TangoTest::read_short_scalar_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_short_scalar_rww(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_short_scalar_rww(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_short_scalar_rww(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_short_scalar_rww) ENABLED START -----*/
 	attr.set_value(attr_short_scalar_rww_read);
 
@@ -1476,7 +1476,7 @@ void TangoTest::read_short_scalar_rww(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute short_scalar_rww related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -1484,7 +1484,7 @@ void TangoTest::read_short_scalar_rww(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_short_scalar_rww(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_short_scalar_rww(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_short_scalar_rww(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevShort	w_val;
 	attr.get_write_value(w_val);
@@ -1495,7 +1495,7 @@ void TangoTest::write_short_scalar_rww(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute short_scalar_w related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -1503,7 +1503,7 @@ void TangoTest::write_short_scalar_rww(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_short_scalar_w(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_short_scalar_w(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_short_scalar_w(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevShort	w_val;
 	attr.get_write_value(w_val);
@@ -1516,7 +1516,7 @@ void TangoTest::write_short_scalar_w(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute string_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Scalar
@@ -1524,7 +1524,7 @@ void TangoTest::write_short_scalar_w(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_string_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_string_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_string_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_string_scalar) ENABLED START -----*/
 	attr.set_value(attr_string_scalar_read);
 
@@ -1533,7 +1533,7 @@ void TangoTest::read_string_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute string_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Scalar
@@ -1541,7 +1541,7 @@ void TangoTest::read_string_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_string_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_string_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_string_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevString	w_val;
 	attr.get_write_value(w_val);
@@ -1565,7 +1565,7 @@ void TangoTest::write_string_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute throw_exception related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -1573,7 +1573,7 @@ void TangoTest::write_string_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_throw_exception(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_throw_exception(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_throw_exception(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_throw_exception) ENABLED START -----*/
   Tango::Except::throw_exception((const char *)"exception test",
 						                     (const char *)"here is the exception you requested",
@@ -1583,7 +1583,7 @@ void TangoTest::read_throw_exception(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute uchar_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Scalar
@@ -1591,7 +1591,7 @@ void TangoTest::read_throw_exception(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_uchar_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_uchar_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_uchar_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_uchar_scalar) ENABLED START -----*/
 	attr.set_value(attr_uchar_scalar_read);
 
@@ -1600,7 +1600,7 @@ void TangoTest::read_uchar_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute uchar_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Scalar
@@ -1608,7 +1608,7 @@ void TangoTest::read_uchar_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_uchar_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_uchar_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_uchar_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevUChar	w_val;
 	attr.get_write_value(w_val);
@@ -1621,7 +1621,7 @@ void TangoTest::write_uchar_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ulong64_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong64
  *	Attr type:	Scalar
@@ -1629,7 +1629,7 @@ void TangoTest::write_uchar_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ulong64_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ulong64_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ulong64_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ulong64_scalar) ENABLED START -----*/
 	attr.set_value(attr_ulong64_scalar_read);
 
@@ -1638,7 +1638,7 @@ void TangoTest::read_ulong64_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute ulong64_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong64
  *	Attr type:	Scalar
@@ -1646,7 +1646,7 @@ void TangoTest::read_ulong64_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_ulong64_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_ulong64_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_ulong64_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevULong64	w_val;
 	attr.get_write_value(w_val);
@@ -1659,7 +1659,7 @@ void TangoTest::write_ulong64_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ushort_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Scalar
@@ -1667,7 +1667,7 @@ void TangoTest::write_ulong64_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ushort_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ushort_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ushort_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ushort_scalar) ENABLED START -----*/
 	attr.set_value(attr_ushort_scalar_read);
 
@@ -1676,7 +1676,7 @@ void TangoTest::read_ushort_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute ushort_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Scalar
@@ -1684,7 +1684,7 @@ void TangoTest::read_ushort_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_ushort_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_ushort_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_ushort_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevUShort	w_val;
 	attr.get_write_value(w_val);
@@ -1697,7 +1697,7 @@ void TangoTest::write_ushort_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ulong_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong
  *	Attr type:	Scalar
@@ -1705,7 +1705,7 @@ void TangoTest::write_ushort_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ulong_scalar(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ulong_scalar(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ulong_scalar(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ulong_scalar) ENABLED START -----*/
 	attr.set_value(attr_ulong_scalar_read);
 
@@ -1714,7 +1714,7 @@ void TangoTest::read_ulong_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute ulong_scalar related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong
  *	Attr type:	Scalar
@@ -1722,7 +1722,7 @@ void TangoTest::read_ulong_scalar(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_ulong_scalar(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_ulong_scalar(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_ulong_scalar(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve write value
 	Tango::DevULong	w_val;
 	attr.get_write_value(w_val);
@@ -1735,7 +1735,7 @@ void TangoTest::write_ulong_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute boolean_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Spectrum max = 4096
@@ -1743,7 +1743,7 @@ void TangoTest::write_ulong_scalar(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_boolean_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_boolean_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_boolean_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_boolean_spectrum) ENABLED START -----*/
 	attr.set_value(attr_boolean_spectrum_read, dimBooleanSpectrum);
 
@@ -1752,7 +1752,7 @@ void TangoTest::read_boolean_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute boolean_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Spectrum max = 4096
@@ -1760,7 +1760,7 @@ void TangoTest::read_boolean_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_boolean_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_boolean_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_boolean_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -1783,7 +1783,7 @@ void TangoTest::write_boolean_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute boolean_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Spectrum max = 4096
@@ -1791,7 +1791,7 @@ void TangoTest::write_boolean_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_boolean_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_boolean_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_boolean_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_boolean_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_boolean_spectrum_ro_read, kSpecLen);
 
@@ -1800,7 +1800,7 @@ void TangoTest::read_boolean_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute double_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 4096
@@ -1808,7 +1808,7 @@ void TangoTest::read_boolean_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_double_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_double_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_double_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_double_spectrum) ENABLED START -----*/
 	attr.set_value(attr_double_spectrum_read, dimDoubleSpectrum);
 
@@ -1817,7 +1817,7 @@ void TangoTest::read_double_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute double_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 4096
@@ -1825,7 +1825,7 @@ void TangoTest::read_double_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_double_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_double_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_double_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -1848,7 +1848,7 @@ void TangoTest::write_double_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute double_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 4096
@@ -1856,7 +1856,7 @@ void TangoTest::write_double_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_double_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_double_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_double_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_double_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_double_spectrum_ro_read, kSpecLen);
 
@@ -1873,7 +1873,7 @@ void TangoTest::read_double_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_float_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_float_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_float_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_float_spectrum) ENABLED START -----*/
 	attr.set_value(attr_float_spectrum_read, dimFloatSpectrum);
 
@@ -1890,7 +1890,7 @@ void TangoTest::read_float_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_float_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_float_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_float_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -1913,7 +1913,7 @@ void TangoTest::write_float_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute float_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevFloat
  *	Attr type:	Spectrum max = 4096
@@ -1921,7 +1921,7 @@ void TangoTest::write_float_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_float_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_float_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_float_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_float_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_float_spectrum_ro_read, kSpecLen);
 
@@ -1930,7 +1930,7 @@ void TangoTest::read_float_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long64_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong64
  *	Attr type:	Spectrum max = 4096
@@ -1938,7 +1938,7 @@ void TangoTest::read_float_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long64_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long64_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long64_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long64_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_long64_spectrum_ro_read, kSpecLen);
 
@@ -1947,7 +1947,7 @@ void TangoTest::read_long64_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Spectrum max = 4096
@@ -1955,7 +1955,7 @@ void TangoTest::read_long64_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long_spectrum) ENABLED START -----*/
 	attr.set_value(attr_long_spectrum_read, dimLongSpectrum);
 
@@ -1964,7 +1964,7 @@ void TangoTest::read_long_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute long_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Spectrum max = 4096
@@ -1972,7 +1972,7 @@ void TangoTest::read_long_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_long_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_long_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_long_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -1995,7 +1995,7 @@ void TangoTest::write_long_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Spectrum max = 4096
@@ -2003,7 +2003,7 @@ void TangoTest::write_long_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_long_spectrum_ro_read, kSpecLen);
 
@@ -2012,7 +2012,7 @@ void TangoTest::read_long_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute short_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Spectrum max = 4096
@@ -2020,7 +2020,7 @@ void TangoTest::read_long_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_short_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_short_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_short_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_short_spectrum) ENABLED START -----*/
 	attr.set_value(attr_short_spectrum_read, dimShortSpectrum);
 
@@ -2029,7 +2029,7 @@ void TangoTest::read_short_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute short_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Spectrum max = 4096
@@ -2037,7 +2037,7 @@ void TangoTest::read_short_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_short_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_short_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_short_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2065,7 +2065,7 @@ void TangoTest::write_short_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute short_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Spectrum max = 4096
@@ -2073,7 +2073,7 @@ void TangoTest::write_short_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_short_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_short_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_short_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_short_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_short_spectrum_ro_read, kSpecLen);
 
@@ -2082,7 +2082,7 @@ void TangoTest::read_short_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute string_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 256
@@ -2090,7 +2090,7 @@ void TangoTest::read_short_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_string_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_string_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_string_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_string_spectrum) ENABLED START -----*/
 	attr.set_value(attr_string_spectrum_read, dimStringSpectrum);
 
@@ -2099,7 +2099,7 @@ void TangoTest::read_string_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute string_spectrum related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 256
@@ -2107,7 +2107,7 @@ void TangoTest::read_string_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_string_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_string_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_string_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2134,7 +2134,7 @@ void TangoTest::write_string_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute string_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 256
@@ -2142,7 +2142,7 @@ void TangoTest::write_string_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_string_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_string_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_string_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_string_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_string_spectrum_ro_read, kSpecLen);
 
@@ -2159,7 +2159,7 @@ void TangoTest::read_string_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_uchar_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_uchar_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_uchar_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_uchar_spectrum) ENABLED START -----*/
 	attr.set_value(attr_uchar_spectrum_read, dimUcharSpectrum);
 
@@ -2176,7 +2176,7 @@ void TangoTest::read_uchar_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_uchar_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_uchar_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_uchar_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2199,7 +2199,7 @@ void TangoTest::write_uchar_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute uchar_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Spectrum max = 4096
@@ -2207,7 +2207,7 @@ void TangoTest::write_uchar_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_uchar_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_uchar_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_uchar_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_uchar_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_uchar_spectrum_ro_read, kSpecLen);
 
@@ -2216,7 +2216,7 @@ void TangoTest::read_uchar_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ulong64_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong64
  *	Attr type:	Spectrum max = 4096
@@ -2224,7 +2224,7 @@ void TangoTest::read_uchar_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ulong64_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ulong64_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ulong64_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ulong64_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_ulong64_spectrum_ro_read, kSpecLen);
 
@@ -2233,7 +2233,7 @@ void TangoTest::read_ulong64_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ulong_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong
  *	Attr type:	Spectrum max = 4096
@@ -2241,7 +2241,7 @@ void TangoTest::read_ulong64_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ulong_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ulong_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ulong_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ulong_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_ulong_spectrum_ro_read, kSpecLen);
 
@@ -2258,7 +2258,7 @@ void TangoTest::read_ulong_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ushort_spectrum(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ushort_spectrum(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ushort_spectrum(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ushort_spectrum) ENABLED START -----*/
 	attr.set_value(attr_ushort_spectrum_read, dimUshortSpectrum);
 
@@ -2275,7 +2275,7 @@ void TangoTest::read_ushort_spectrum(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_ushort_spectrum(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_ushort_spectrum(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_ushort_spectrum(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2298,7 +2298,7 @@ void TangoTest::write_ushort_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ushort_spectrum_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Spectrum max = 4096
@@ -2306,7 +2306,7 @@ void TangoTest::write_ushort_spectrum(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ushort_spectrum_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ushort_spectrum_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ushort_spectrum_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ushort_spectrum_ro) ENABLED START -----*/
 	attr.set_value(attr_ushort_spectrum_ro_read, kSpecLen);
 
@@ -2315,7 +2315,7 @@ void TangoTest::read_ushort_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute wave related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 4096
@@ -2323,7 +2323,7 @@ void TangoTest::read_ushort_spectrum_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_wave(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_wave(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_wave(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_wave) ENABLED START -----*/
 	attr.set_value(attr_wave_read, kSpecLen);
 
@@ -2332,7 +2332,7 @@ void TangoTest::read_wave(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute boolean_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Image max = 251 x 251
@@ -2340,7 +2340,7 @@ void TangoTest::read_wave(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_boolean_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_boolean_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_boolean_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_boolean_image) ENABLED START -----*/
 	attr.set_value(attr_boolean_image_read, dimXBooleanImage, dimYBooleanImage);
 
@@ -2349,7 +2349,7 @@ void TangoTest::read_boolean_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute boolean_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Image max = 251 x 251
@@ -2357,7 +2357,7 @@ void TangoTest::read_boolean_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_boolean_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_boolean_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_boolean_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2383,7 +2383,7 @@ void TangoTest::write_boolean_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute boolean_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Image max = 251 x 251
@@ -2391,7 +2391,7 @@ void TangoTest::write_boolean_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_boolean_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_boolean_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_boolean_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_boolean_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		boolean_image_lock.lock();
@@ -2403,7 +2403,7 @@ void TangoTest::read_boolean_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute double_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Image max = 251 x 251
@@ -2411,7 +2411,7 @@ void TangoTest::read_boolean_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_double_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_double_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_double_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_double_image) ENABLED START -----*/
 	attr.set_value(attr_double_image_read, dimXDoubleImage, dimYDoubleImage);
 
@@ -2420,7 +2420,7 @@ void TangoTest::read_double_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute double_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Image max = 251 x 251
@@ -2428,7 +2428,7 @@ void TangoTest::read_double_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_double_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_double_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_double_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2454,7 +2454,7 @@ void TangoTest::write_double_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute double_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Image max = 251 x 251
@@ -2462,7 +2462,7 @@ void TangoTest::write_double_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_double_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_double_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_double_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_double_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		double_image_lock.lock();
@@ -2474,7 +2474,7 @@ void TangoTest::read_double_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute float_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevFloat
  *	Attr type:	Image max = 251 x 251
@@ -2482,7 +2482,7 @@ void TangoTest::read_double_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_float_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_float_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_float_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_float_image) ENABLED START -----*/
 	attr.set_value(attr_float_image_read, dimXFloatImage, dimYFloatImage);
 
@@ -2491,7 +2491,7 @@ void TangoTest::read_float_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute float_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevFloat
  *	Attr type:	Image max = 251 x 251
@@ -2499,7 +2499,7 @@ void TangoTest::read_float_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_float_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_float_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_float_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2533,7 +2533,7 @@ void TangoTest::write_float_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_float_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_float_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_float_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_float_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		float_image_lock.lock();
@@ -2546,7 +2546,7 @@ void TangoTest::read_float_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long64_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong64
  *	Attr type:	Image max = 251 x 251
@@ -2554,7 +2554,7 @@ void TangoTest::read_float_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long64_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long64_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long64_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long64_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		long64_image_lock.lock();
@@ -2567,7 +2567,7 @@ void TangoTest::read_long64_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Image max = 251 x 251
@@ -2575,7 +2575,7 @@ void TangoTest::read_long64_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long_image) ENABLED START -----*/
 	attr.set_value(attr_long_image_read, kImagLen, kImagLen);
 
@@ -2584,7 +2584,7 @@ void TangoTest::read_long_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute long_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Image max = 251 x 251
@@ -2592,7 +2592,7 @@ void TangoTest::read_long_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_long_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_long_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_long_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2618,7 +2618,7 @@ void TangoTest::write_long_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute long_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Image max = 251 x 251
@@ -2626,7 +2626,7 @@ void TangoTest::write_long_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_long_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_long_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_long_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_long_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		long_image_lock.lock();
@@ -2638,7 +2638,7 @@ void TangoTest::read_long_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute short_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Image max = 251 x 251
@@ -2646,7 +2646,7 @@ void TangoTest::read_long_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_short_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_short_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_short_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_short_image) ENABLED START -----*/
 	attr.set_value(attr_short_image_read, dimXShortImage, dimYShortImage);
 
@@ -2655,7 +2655,7 @@ void TangoTest::read_short_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute short_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Image max = 251 x 251
@@ -2663,7 +2663,7 @@ void TangoTest::read_short_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_short_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_short_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_short_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2689,7 +2689,7 @@ void TangoTest::write_short_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute short_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Image max = 251 x 251
@@ -2697,7 +2697,7 @@ void TangoTest::write_short_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_short_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_short_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_short_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_short_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		short_image_lock.lock();
@@ -2709,7 +2709,7 @@ void TangoTest::read_short_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute string_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Image max = 256 x 256
@@ -2717,7 +2717,7 @@ void TangoTest::read_short_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_string_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_string_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_string_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_string_image) ENABLED START -----*/
 	attr.set_value(attr_string_image_read, dimXStringImage, dimYStringImage);
 
@@ -2726,7 +2726,7 @@ void TangoTest::read_string_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute string_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Image max = 256 x 256
@@ -2734,7 +2734,7 @@ void TangoTest::read_string_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_string_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_string_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_string_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2769,7 +2769,7 @@ void TangoTest::write_string_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute string_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Image max = 256 x 256
@@ -2777,7 +2777,7 @@ void TangoTest::write_string_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_string_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_string_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_string_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_string_image_ro) ENABLED START -----*/
 	attr.set_value(attr_string_image_ro_read, kImagLen, kImagLen);
 
@@ -2786,7 +2786,7 @@ void TangoTest::read_string_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute uchar_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Image max = 251 x 251
@@ -2794,7 +2794,7 @@ void TangoTest::read_string_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_uchar_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_uchar_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_uchar_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_uchar_image) ENABLED START -----*/
 	attr.set_value(attr_uchar_image_read, dimXUcharImage, dimYUcharImage);
 
@@ -2803,7 +2803,7 @@ void TangoTest::read_uchar_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute uchar_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Image max = 251 x 251
@@ -2811,7 +2811,7 @@ void TangoTest::read_uchar_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_uchar_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_uchar_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_uchar_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2845,7 +2845,7 @@ void TangoTest::write_uchar_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_uchar_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_uchar_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_uchar_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_uchar_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		uchar_image_lock.lock();
@@ -2857,7 +2857,7 @@ void TangoTest::read_uchar_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ulong64_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong64
  *	Attr type:	Image max = 251 x 251
@@ -2865,7 +2865,7 @@ void TangoTest::read_uchar_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ulong64_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ulong64_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ulong64_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ulong64_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		ulong64_image_lock.lock();
@@ -2877,7 +2877,7 @@ void TangoTest::read_ulong64_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ulong_image_ro related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong
  *	Attr type:	Image max = 251 x 251
@@ -2885,7 +2885,7 @@ void TangoTest::read_ulong64_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ulong_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ulong_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ulong_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ulong_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		ulong_image_lock.lock();
@@ -2897,7 +2897,7 @@ void TangoTest::read_ulong_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Read attribute ushort_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Image max = 251 x 251
@@ -2905,7 +2905,7 @@ void TangoTest::read_ulong_image_ro(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ushort_image(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ushort_image(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ushort_image(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ushort_image) ENABLED START -----*/
 	attr.set_value(attr_ushort_image_read, dimXUshortImage, dimYUshortImage);
 
@@ -2914,7 +2914,7 @@ void TangoTest::read_ushort_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 /**
  *	Write attribute ushort_image related method
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Image max = 251 x 251
@@ -2922,7 +2922,7 @@ void TangoTest::read_ushort_image(Tango::Attribute &attr)
 //--------------------------------------------------------
 void TangoTest::write_ushort_image(Tango::WAttribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::write_ushort_image(Tango::WAttribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::write_ushort_image(Tango::WAttribute &attr) entering... " << std::endl;
 	//	Retrieve number of write values
 	int	w_length = attr.get_write_value_length();
 
@@ -2956,7 +2956,7 @@ void TangoTest::write_ushort_image(Tango::WAttribute &attr)
 //--------------------------------------------------------
 void TangoTest::read_ushort_image_ro(Tango::Attribute &attr)
 {
-	DEBUG_STREAM << "TangoTest::read_ushort_image_ro(Tango::Attribute &attr) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_ushort_image_ro(Tango::Attribute &attr) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_ushort_image_ro) ENABLED START -----*/
 	if (mthreaded_impl != 0)
 		ushort_image_lock.lock();
@@ -2990,7 +2990,7 @@ void TangoTest::add_dynamic_attributes()
 //--------------------------------------------------------
 void TangoTest::read_string_long_short_ro(Tango::Pipe &pipe)
 {
-	DEBUG_STREAM << "TangoTest::read_string_long_short_ro(Tango::Pipe &pipe) entering... " << endl;
+	DEBUG_STREAM << "TangoTest::read_string_long_short_ro(Tango::Pipe &pipe) entering... " << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::read_string_long_short_ro) ENABLED START -----*/
 
     vector<string> de_names;
@@ -3012,7 +3012,7 @@ void TangoTest::read_string_long_short_ro(Tango::Pipe &pipe)
 //--------------------------------------------------------
 void TangoTest::crash_from_developper_thread()
 {
-	DEBUG_STREAM << "TangoTest::CrashFromDevelopperThread()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::CrashFromDevelopperThread()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::crash_from_developper_thread) ENABLED START -----*/
 
 	//	Add your own code
@@ -3037,7 +3037,7 @@ void TangoTest::crash_from_developper_thread()
 //--------------------------------------------------------
 void TangoTest::crash_from_omni_thread()
 {
-	DEBUG_STREAM << "TangoTest::CrashFromOmniThread()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::CrashFromOmniThread()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::crash_from_omni_thread) ENABLED START -----*/
 
 	//	Add your own code
@@ -3066,7 +3066,7 @@ void TangoTest::crash_from_omni_thread()
 Tango::DevBoolean TangoTest::dev_boolean(Tango::DevBoolean argin)
 {
 	Tango::DevBoolean argout;
-	DEBUG_STREAM << "TangoTest::DevBoolean()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevBoolean()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_boolean) ENABLED START -----*/
 
 	//	Add your own code
@@ -3088,7 +3088,7 @@ Tango::DevBoolean TangoTest::dev_boolean(Tango::DevBoolean argin)
 Tango::DevDouble TangoTest::dev_double(Tango::DevDouble argin)
 {
 	Tango::DevDouble argout;
-	DEBUG_STREAM << "TangoTest::DevDouble()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevDouble()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_double) ENABLED START -----*/
 
 	//	Add your own code
@@ -3110,7 +3110,7 @@ Tango::DevDouble TangoTest::dev_double(Tango::DevDouble argin)
 Tango::DevFloat TangoTest::dev_float(Tango::DevFloat argin)
 {
 	Tango::DevFloat argout;
-	DEBUG_STREAM << "TangoTest::DevFloat()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevFloat()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_float) ENABLED START -----*/
 
 	//	Add your own code
@@ -3132,7 +3132,7 @@ Tango::DevFloat TangoTest::dev_float(Tango::DevFloat argin)
 Tango::DevLong TangoTest::dev_long(Tango::DevLong argin)
 {
 	Tango::DevLong argout;
-	DEBUG_STREAM << "TangoTest::DevLong()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevLong()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_long) ENABLED START -----*/
 
 	//	Add your own code
@@ -3154,7 +3154,7 @@ Tango::DevLong TangoTest::dev_long(Tango::DevLong argin)
 Tango::DevLong64 TangoTest::dev_long64(Tango::DevLong64 argin)
 {
 	Tango::DevLong64 argout;
-	DEBUG_STREAM << "TangoTest::DevLong64()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevLong64()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_long64) ENABLED START -----*/
 
 	//	Add your own code
@@ -3175,7 +3175,7 @@ Tango::DevLong64 TangoTest::dev_long64(Tango::DevLong64 argin)
 Tango::DevShort TangoTest::dev_short(Tango::DevShort argin)
 {
 	Tango::DevShort argout;
-	DEBUG_STREAM << "TangoTest::DevShort()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevShort()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_short) ENABLED START -----*/
 
 	//	Add your own code
@@ -3197,7 +3197,7 @@ Tango::DevShort TangoTest::dev_short(Tango::DevShort argin)
 Tango::DevString TangoTest::dev_string(Tango::DevString argin)
 {
 	Tango::DevString argout;
-	DEBUG_STREAM << "TangoTest::DevString()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevString()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_string) ENABLED START -----*/
 
 	//	Add your own code
@@ -3230,7 +3230,7 @@ Tango::DevString TangoTest::dev_string(Tango::DevString argin)
 Tango::DevULong TangoTest::dev_ulong(Tango::DevULong argin)
 {
 	Tango::DevULong argout;
-	DEBUG_STREAM << "TangoTest::DevULong()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevULong()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_ulong) ENABLED START -----*/
 
 	//	Add your own code
@@ -3252,7 +3252,7 @@ Tango::DevULong TangoTest::dev_ulong(Tango::DevULong argin)
 Tango::DevULong64 TangoTest::dev_ulong64(Tango::DevULong64 argin)
 {
 	Tango::DevULong64 argout;
-	DEBUG_STREAM << "TangoTest::DevULong64()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevULong64()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_ulong64) ENABLED START -----*/
 
 	//	Add your own code
@@ -3273,7 +3273,7 @@ Tango::DevULong64 TangoTest::dev_ulong64(Tango::DevULong64 argin)
 Tango::DevUShort TangoTest::dev_ushort(Tango::DevUShort argin)
 {
 	Tango::DevUShort argout;
-	DEBUG_STREAM << "TangoTest::DevUShort()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevUShort()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_ushort) ENABLED START -----*/
 
 	//	Add your own code
@@ -3295,7 +3295,7 @@ Tango::DevUShort TangoTest::dev_ushort(Tango::DevUShort argin)
 Tango::DevVarCharArray *TangoTest::dev_var_char_array(const Tango::DevVarCharArray *argin)
 {
 	Tango::DevVarCharArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarCharArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarCharArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_char_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3335,7 +3335,7 @@ Tango::DevVarCharArray *TangoTest::dev_var_char_array(const Tango::DevVarCharArr
 Tango::DevVarDoubleArray *TangoTest::dev_var_double_array(const Tango::DevVarDoubleArray *argin)
 {
 	Tango::DevVarDoubleArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarDoubleArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarDoubleArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_double_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3375,7 +3375,7 @@ Tango::DevVarDoubleArray *TangoTest::dev_var_double_array(const Tango::DevVarDou
 Tango::DevVarDoubleStringArray *TangoTest::dev_var_double_string_array(const Tango::DevVarDoubleStringArray *argin)
 {
 	Tango::DevVarDoubleStringArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarDoubleStringArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarDoubleStringArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_double_string_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3416,7 +3416,7 @@ Tango::DevVarDoubleStringArray *TangoTest::dev_var_double_string_array(const Tan
 Tango::DevVarFloatArray *TangoTest::dev_var_float_array(const Tango::DevVarFloatArray *argin)
 {
 	Tango::DevVarFloatArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarFloatArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarFloatArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_float_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3447,16 +3447,16 @@ Tango::DevVarFloatArray *TangoTest::dev_var_float_array(const Tango::DevVarFloat
 //--------------------------------------------------------
 /**
  *	Command DevVarLong64Array related method
- *	Description:
+ *	Description: 
  *
- *	@param argin
- *	@returns
+ *	@param argin 
+ *	@returns 
  */
 //--------------------------------------------------------
 Tango::DevVarLong64Array *TangoTest::dev_var_long64_array(const Tango::DevVarLong64Array *argin)
 {
 	Tango::DevVarLong64Array *argout;
-	DEBUG_STREAM << "TangoTest::DevVarLong64Array()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarLong64Array()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_long64_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3496,7 +3496,7 @@ Tango::DevVarLong64Array *TangoTest::dev_var_long64_array(const Tango::DevVarLon
 Tango::DevVarLongArray *TangoTest::dev_var_long_array(const Tango::DevVarLongArray *argin)
 {
 	Tango::DevVarLongArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarLongArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarLongArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_long_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3536,7 +3536,7 @@ Tango::DevVarLongArray *TangoTest::dev_var_long_array(const Tango::DevVarLongArr
 Tango::DevVarLongStringArray *TangoTest::dev_var_long_string_array(const Tango::DevVarLongStringArray *argin)
 {
 	Tango::DevVarLongStringArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarLongStringArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarLongStringArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_long_string_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3577,7 +3577,7 @@ Tango::DevVarLongStringArray *TangoTest::dev_var_long_string_array(const Tango::
 Tango::DevVarShortArray *TangoTest::dev_var_short_array(const Tango::DevVarShortArray *argin)
 {
 	Tango::DevVarShortArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarShortArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarShortArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_short_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3617,7 +3617,7 @@ Tango::DevVarShortArray *TangoTest::dev_var_short_array(const Tango::DevVarShort
 Tango::DevVarStringArray *TangoTest::dev_var_string_array(const Tango::DevVarStringArray *argin)
 {
 	Tango::DevVarStringArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarStringArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarStringArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_string_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3648,16 +3648,16 @@ Tango::DevVarStringArray *TangoTest::dev_var_string_array(const Tango::DevVarStr
 //--------------------------------------------------------
 /**
  *	Command DevVarULong64Array related method
- *	Description:
+ *	Description: 
  *
- *	@param argin
- *	@returns
+ *	@param argin 
+ *	@returns 
  */
 //--------------------------------------------------------
 Tango::DevVarULong64Array *TangoTest::dev_var_ulong64_array(const Tango::DevVarULong64Array *argin)
 {
 	Tango::DevVarULong64Array *argout;
-	DEBUG_STREAM << "TangoTest::DevVarULong64Array()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarULong64Array()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_ulong64_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3697,7 +3697,7 @@ Tango::DevVarULong64Array *TangoTest::dev_var_ulong64_array(const Tango::DevVarU
 Tango::DevVarULongArray *TangoTest::dev_var_ulong_array(const Tango::DevVarULongArray *argin)
 {
 	Tango::DevVarULongArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarULongArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarULongArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_ulong_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3737,7 +3737,7 @@ Tango::DevVarULongArray *TangoTest::dev_var_ulong_array(const Tango::DevVarULong
 Tango::DevVarUShortArray *TangoTest::dev_var_ushort_array(const Tango::DevVarUShortArray *argin)
 {
 	Tango::DevVarUShortArray *argout;
-	DEBUG_STREAM << "TangoTest::DevVarUShortArray()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVarUShortArray()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_var_ushort_array) ENABLED START -----*/
 
 	//	Add your own code
@@ -3774,7 +3774,7 @@ Tango::DevVarUShortArray *TangoTest::dev_var_ushort_array(const Tango::DevVarUSh
 //--------------------------------------------------------
 void TangoTest::dev_void()
 {
-	DEBUG_STREAM << "TangoTest::DevVoid()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DevVoid()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dev_void) ENABLED START -----*/
 
 	//	Add your own code
@@ -3791,7 +3791,7 @@ void TangoTest::dev_void()
 //--------------------------------------------------------
 void TangoTest::dump_execution_state()
 {
-	DEBUG_STREAM << "TangoTest::DumpExecutionState()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::DumpExecutionState()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::dump_execution_state) ENABLED START -----*/
 
 	//	Add your own code
@@ -3815,7 +3815,7 @@ void TangoTest::dump_execution_state()
 //--------------------------------------------------------
 void TangoTest::switch_states()
 {
-	DEBUG_STREAM << "TangoTest::SwitchStates()  - " << device_name << endl;
+	DEBUG_STREAM << "TangoTest::SwitchStates()  - " << device_name << std::endl;
 	/*----- PROTECTED REGION ID(TangoTest::switch_states) ENABLED START -----*/
 
 	//	Add your own code

--- a/TangoTest.h
+++ b/TangoTest.h
@@ -190,7 +190,7 @@ public:
 	 *	@param cl	Class.
 	 *	@param s 	Device Name
 	 */
-	TangoTest(Tango::DeviceClass *cl,string &s);
+	TangoTest(Tango::DeviceClass *cl,std::string &s);
 	/**
 	 * Constructs a newly device object.
 	 *
@@ -240,18 +240,18 @@ public:
 	 *	Description : Hardware acquisition for attributes.
 	 */
 	//--------------------------------------------------------
-	virtual void read_attr_hardware(vector<long> &attr_list);
+	virtual void read_attr_hardware(std::vector<long> &attr_list);
 	//--------------------------------------------------------
 	/*
 	 *	Method      : TangoTest::write_attr_hardware()
 	 *	Description : Hardware writing for attributes.
 	 */
 	//--------------------------------------------------------
-	virtual void write_attr_hardware(vector<long> &attr_list);
+	virtual void write_attr_hardware(std::vector<long> &attr_list);
 
 /**
  *	Attribute ampli related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -270,7 +270,7 @@ public:
 	virtual bool is_boolean_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute double_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -280,7 +280,7 @@ public:
 	virtual bool is_double_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute double_scalar_rww related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -290,7 +290,7 @@ public:
 	virtual bool is_double_scalar_rww_allowed(Tango::AttReqType type);
 /**
  *	Attribute double_scalar_w related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Scalar
@@ -309,7 +309,7 @@ public:
 	virtual bool is_float_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute long64_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong64
  *	Attr type:	Scalar
@@ -319,7 +319,7 @@ public:
 	virtual bool is_long64_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute long_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -329,7 +329,7 @@ public:
 	virtual bool is_long_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute long_scalar_rww related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -339,7 +339,7 @@ public:
 	virtual bool is_long_scalar_rww_allowed(Tango::AttReqType type);
 /**
  *	Attribute long_scalar_w related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -348,7 +348,7 @@ public:
 	virtual bool is_long_scalar_w_allowed(Tango::AttReqType type);
 /**
  *	Attribute no_value related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -357,7 +357,7 @@ public:
 	virtual bool is_no_value_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -367,7 +367,7 @@ public:
 	virtual bool is_short_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_scalar_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -376,7 +376,7 @@ public:
 	virtual bool is_short_scalar_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_scalar_rww related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -386,7 +386,7 @@ public:
 	virtual bool is_short_scalar_rww_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_scalar_w related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Scalar
@@ -395,7 +395,7 @@ public:
 	virtual bool is_short_scalar_w_allowed(Tango::AttReqType type);
 /**
  *	Attribute string_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Scalar
@@ -405,7 +405,7 @@ public:
 	virtual bool is_string_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute throw_exception related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Scalar
@@ -414,7 +414,7 @@ public:
 	virtual bool is_throw_exception_allowed(Tango::AttReqType type);
 /**
  *	Attribute uchar_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Scalar
@@ -424,7 +424,7 @@ public:
 	virtual bool is_uchar_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute ulong64_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong64
  *	Attr type:	Scalar
@@ -434,7 +434,7 @@ public:
 	virtual bool is_ulong64_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute ushort_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Scalar
@@ -444,7 +444,7 @@ public:
 	virtual bool is_ushort_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute ulong_scalar related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong
  *	Attr type:	Scalar
@@ -454,7 +454,7 @@ public:
 	virtual bool is_ulong_scalar_allowed(Tango::AttReqType type);
 /**
  *	Attribute boolean_spectrum related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Spectrum max = 4096
@@ -464,7 +464,7 @@ public:
 	virtual bool is_boolean_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute boolean_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Spectrum max = 4096
@@ -473,7 +473,7 @@ public:
 	virtual bool is_boolean_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute double_spectrum related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 4096
@@ -483,7 +483,7 @@ public:
 	virtual bool is_double_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute double_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 4096
@@ -502,7 +502,7 @@ public:
 	virtual bool is_float_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute float_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevFloat
  *	Attr type:	Spectrum max = 4096
@@ -511,7 +511,7 @@ public:
 	virtual bool is_float_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute long64_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong64
  *	Attr type:	Spectrum max = 4096
@@ -520,7 +520,7 @@ public:
 	virtual bool is_long64_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute long_spectrum related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Spectrum max = 4096
@@ -530,7 +530,7 @@ public:
 	virtual bool is_long_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute long_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Spectrum max = 4096
@@ -539,7 +539,7 @@ public:
 	virtual bool is_long_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_spectrum related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Spectrum max = 4096
@@ -549,7 +549,7 @@ public:
 	virtual bool is_short_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Spectrum max = 4096
@@ -558,7 +558,7 @@ public:
 	virtual bool is_short_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute string_spectrum related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 256
@@ -568,7 +568,7 @@ public:
 	virtual bool is_string_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute string_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Spectrum max = 256
@@ -587,7 +587,7 @@ public:
 	virtual bool is_uchar_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute uchar_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Spectrum max = 4096
@@ -596,7 +596,7 @@ public:
 	virtual bool is_uchar_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute ulong64_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong64
  *	Attr type:	Spectrum max = 4096
@@ -605,7 +605,7 @@ public:
 	virtual bool is_ulong64_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute ulong_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong
  *	Attr type:	Spectrum max = 4096
@@ -624,7 +624,7 @@ public:
 	virtual bool is_ushort_spectrum_allowed(Tango::AttReqType type);
 /**
  *	Attribute ushort_spectrum_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Spectrum max = 4096
@@ -633,7 +633,7 @@ public:
 	virtual bool is_ushort_spectrum_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute wave related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Spectrum max = 4096
@@ -642,7 +642,7 @@ public:
 	virtual bool is_wave_allowed(Tango::AttReqType type);
 /**
  *	Attribute boolean_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Image max = 251 x 251
@@ -652,7 +652,7 @@ public:
 	virtual bool is_boolean_image_allowed(Tango::AttReqType type);
 /**
  *	Attribute boolean_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevBoolean
  *	Attr type:	Image max = 251 x 251
@@ -661,7 +661,7 @@ public:
 	virtual bool is_boolean_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute double_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Image max = 251 x 251
@@ -671,7 +671,7 @@ public:
 	virtual bool is_double_image_allowed(Tango::AttReqType type);
 /**
  *	Attribute double_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevDouble
  *	Attr type:	Image max = 251 x 251
@@ -680,7 +680,7 @@ public:
 	virtual bool is_double_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute float_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevFloat
  *	Attr type:	Image max = 251 x 251
@@ -699,7 +699,7 @@ public:
 	virtual bool is_float_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute long64_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong64
  *	Attr type:	Image max = 251 x 251
@@ -708,7 +708,7 @@ public:
 	virtual bool is_long64_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute long_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Image max = 251 x 251
@@ -718,7 +718,7 @@ public:
 	virtual bool is_long_image_allowed(Tango::AttReqType type);
 /**
  *	Attribute long_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevLong
  *	Attr type:	Image max = 251 x 251
@@ -727,7 +727,7 @@ public:
 	virtual bool is_long_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Image max = 251 x 251
@@ -737,7 +737,7 @@ public:
 	virtual bool is_short_image_allowed(Tango::AttReqType type);
 /**
  *	Attribute short_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevShort
  *	Attr type:	Image max = 251 x 251
@@ -746,7 +746,7 @@ public:
 	virtual bool is_short_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute string_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Image max = 256 x 256
@@ -756,7 +756,7 @@ public:
 	virtual bool is_string_image_allowed(Tango::AttReqType type);
 /**
  *	Attribute string_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevString
  *	Attr type:	Image max = 256 x 256
@@ -765,7 +765,7 @@ public:
 	virtual bool is_string_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute uchar_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUChar
  *	Attr type:	Image max = 251 x 251
@@ -784,7 +784,7 @@ public:
 	virtual bool is_uchar_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute ulong64_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong64
  *	Attr type:	Image max = 251 x 251
@@ -793,7 +793,7 @@ public:
 	virtual bool is_ulong64_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute ulong_image_ro related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevULong
  *	Attr type:	Image max = 251 x 251
@@ -802,7 +802,7 @@ public:
 	virtual bool is_ulong_image_ro_allowed(Tango::AttReqType type);
 /**
  *	Attribute ushort_image related methods
- *	Description:
+ *	Description: 
  *
  *	Data type:	Tango::DevUShort
  *	Attr type:	Image max = 251 x 251
@@ -981,10 +981,10 @@ public:
 	virtual bool is_DevVarFloatArray_allowed(const CORBA::Any &any);
 	/**
 	 *	Command DevVarLong64Array related method
-	 *	Description:
+	 *	Description: 
 	 *
-	 *	@param argin
-	 *	@returns
+	 *	@param argin 
+	 *	@returns 
 	 */
 	virtual Tango::DevVarLong64Array *dev_var_long64_array(const Tango::DevVarLong64Array *argin);
 	virtual bool is_DevVarLong64Array_allowed(const CORBA::Any &any);
@@ -1026,10 +1026,10 @@ public:
 	virtual bool is_DevVarStringArray_allowed(const CORBA::Any &any);
 	/**
 	 *	Command DevVarULong64Array related method
-	 *	Description:
+	 *	Description: 
 	 *
-	 *	@param argin
-	 *	@returns
+	 *	@param argin 
+	 *	@returns 
 	 */
 	virtual Tango::DevVarULong64Array *dev_var_ulong64_array(const Tango::DevVarULong64Array *argin);
 	virtual bool is_DevVarULong64Array_allowed(const CORBA::Any &any);

--- a/TangoTest.h
+++ b/TangoTest.h
@@ -108,7 +108,7 @@ public:
 
 	Tango::DevString	attr_string_image_write;
 
-    string              pi_str;
+    std::string         pi_str;
     Tango::DevLong      pi_long;
     Tango::DevShort     pi_short;
 

--- a/TangoTest.xmi
+++ b/TangoTest.xmi
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
-  <classes name="TangoTest" pogoRevision="9.1">
-    <description description="A device to test generic clients. It offers a \&quot;echo\&quot; like command for&#xA;each TANGO data type (i.e. each command returns an exact copy of &lt;argin>)." title="TANGO Device Server for testing generic clients" sourcePath="/home/taurel/tango/TangoTest" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" license="GPL" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
-      <inheritances classname="Device_4Impl" sourcePath="/segfs/tango/templates/AbstractClasses"/>
+  <classes name="TangoTest" pogoRevision="9.7">
+    <description description="A device to test generic clients. It offers a \&quot;echo\&quot; like command for&#xA;each TANGO data type (i.e. each command returns an exact copy of &lt;argin>)." title="TANGO Device Server for testing generic clients" sourcePath="/Users/benjaminbertrand/Dev/Tango/centos7/TangoTest" language="Cpp" filestogenerate="XMI   file,Code files,Protected Regions" license="GPL" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
+      <inheritances classname="Device_4Impl" sourcePath="../../../../../../segfs/tango/templates/AbstractClasses"/>
       <identification contact="at esrf.fr - tango" author="tango" emailDomain="esrf.fr" classFamily="Miscellaneous" siteSpecific="" platform="All Platforms" bus="Not Applicable" manufacturer="Tango Team" reference="TangoTest"/>
     </description>
     <deviceProperties name="Mthreaded_impl" description="Multi-threaded implementation (true/false">
@@ -709,6 +709,6 @@
     <states name="RUNNING" description="This state allows all the commands to be sent">
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </states>
-    <preferences docHome="./doc_html" makefileHome="/segfs/tango/cppserver/env"/>
+    <preferences docHome="./doc_html" makefileHome="$(TANGO_HOME)"/>
   </classes>
 </pogoDsl:PogoSystem>

--- a/TangoTestClass.cpp
+++ b/TangoTestClass.cpp
@@ -77,15 +77,15 @@ TangoTestClass *TangoTestClass::_instance = NULL;
 
 //--------------------------------------------------------
 /**
- * method : 		TangoTestClass::TangoTestClass(string &s)
+ * method : 		TangoTestClass::TangoTestClass(std::string &s)
  * description : 	constructor for the TangoTestClass
  *
  * @param s	The class name
  */
 //--------------------------------------------------------
-TangoTestClass::TangoTestClass(string &s):Tango::DeviceClass(s)
+TangoTestClass::TangoTestClass(std::string &s):Tango::DeviceClass(s)
 {
-	cout2 << "Entering TangoTestClass constructor" << endl;
+	cout2 << "Entering TangoTestClass constructor" << std::endl;
 	set_default_property();
 	write_class_property();
 
@@ -93,7 +93,7 @@ TangoTestClass::TangoTestClass(string &s):Tango::DeviceClass(s)
 	
 	/*----- PROTECTED REGION END -----*/	//	TangoTestClass::constructor
 
-	cout2 << "Leaving TangoTestClass constructor" << endl;
+	cout2 << "Leaving TangoTestClass constructor" << std::endl;
 }
 
 //--------------------------------------------------------
@@ -127,10 +127,10 @@ TangoTestClass *TangoTestClass::init(const char *name)
 	{
 		try
 		{
-			string s(name);
+			std::string s(name);
 			_instance = new TangoTestClass(s);
 		}
-		catch (bad_alloc &)
+		catch (std::bad_alloc &)
 		{
 			throw;
 		}
@@ -149,7 +149,7 @@ TangoTestClass *TangoTestClass::instance()
 {
 	if (_instance == NULL)
 	{
-		cerr << "Class is not initialised !!" << endl;
+		std::cerr << "Class is not initialised !!" << std::endl;
 		exit(-1);
 	}
 	return _instance;
@@ -173,7 +173,7 @@ TangoTestClass *TangoTestClass::instance()
 //--------------------------------------------------------
 CORBA::Any *CrashFromDevelopperThreadClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "CrashFromDevelopperThreadClass::execute(): arrived" << endl;
+	cout2 << "CrashFromDevelopperThreadClass::execute(): arrived" << std::endl;
 	((static_cast<TangoTest *>(device))->crash_from_developper_thread());
 	return new CORBA::Any();
 }
@@ -191,7 +191,7 @@ CORBA::Any *CrashFromDevelopperThreadClass::execute(Tango::DeviceImpl *device, T
 //--------------------------------------------------------
 CORBA::Any *CrashFromOmniThreadClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "CrashFromOmniThreadClass::execute(): arrived" << endl;
+	cout2 << "CrashFromOmniThreadClass::execute(): arrived" << std::endl;
 	((static_cast<TangoTest *>(device))->crash_from_omni_thread());
 	return new CORBA::Any();
 }
@@ -209,7 +209,7 @@ CORBA::Any *CrashFromOmniThreadClass::execute(Tango::DeviceImpl *device, TANGO_U
 //--------------------------------------------------------
 CORBA::Any *DevBooleanClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevBooleanClass::execute(): arrived" << endl;
+	cout2 << "DevBooleanClass::execute(): arrived" << std::endl;
 	Tango::DevBoolean argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_boolean(argin));
@@ -228,7 +228,7 @@ CORBA::Any *DevBooleanClass::execute(Tango::DeviceImpl *device, const CORBA::Any
 //--------------------------------------------------------
 CORBA::Any *DevDoubleClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevDoubleClass::execute(): arrived" << endl;
+	cout2 << "DevDoubleClass::execute(): arrived" << std::endl;
 	Tango::DevDouble argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_double(argin));
@@ -247,7 +247,7 @@ CORBA::Any *DevDoubleClass::execute(Tango::DeviceImpl *device, const CORBA::Any 
 //--------------------------------------------------------
 CORBA::Any *DevFloatClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevFloatClass::execute(): arrived" << endl;
+	cout2 << "DevFloatClass::execute(): arrived" << std::endl;
 	Tango::DevFloat argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_float(argin));
@@ -266,7 +266,7 @@ CORBA::Any *DevFloatClass::execute(Tango::DeviceImpl *device, const CORBA::Any &
 //--------------------------------------------------------
 CORBA::Any *DevLongClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevLongClass::execute(): arrived" << endl;
+	cout2 << "DevLongClass::execute(): arrived" << std::endl;
 	Tango::DevLong argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_long(argin));
@@ -285,7 +285,7 @@ CORBA::Any *DevLongClass::execute(Tango::DeviceImpl *device, const CORBA::Any &i
 //--------------------------------------------------------
 CORBA::Any *DevLong64Class::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevLong64Class::execute(): arrived" << endl;
+	cout2 << "DevLong64Class::execute(): arrived" << std::endl;
 	Tango::DevLong64 argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_long64(argin));
@@ -304,7 +304,7 @@ CORBA::Any *DevLong64Class::execute(Tango::DeviceImpl *device, const CORBA::Any 
 //--------------------------------------------------------
 CORBA::Any *DevShortClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevShortClass::execute(): arrived" << endl;
+	cout2 << "DevShortClass::execute(): arrived" << std::endl;
 	Tango::DevShort argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_short(argin));
@@ -323,7 +323,7 @@ CORBA::Any *DevShortClass::execute(Tango::DeviceImpl *device, const CORBA::Any &
 //--------------------------------------------------------
 CORBA::Any *DevStringClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevStringClass::execute(): arrived" << endl;
+	cout2 << "DevStringClass::execute(): arrived" << std::endl;
 	Tango::DevString argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_string(argin));
@@ -342,7 +342,7 @@ CORBA::Any *DevStringClass::execute(Tango::DeviceImpl *device, const CORBA::Any 
 //--------------------------------------------------------
 CORBA::Any *DevULongClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevULongClass::execute(): arrived" << endl;
+	cout2 << "DevULongClass::execute(): arrived" << std::endl;
 	Tango::DevULong argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_ulong(argin));
@@ -361,7 +361,7 @@ CORBA::Any *DevULongClass::execute(Tango::DeviceImpl *device, const CORBA::Any &
 //--------------------------------------------------------
 CORBA::Any *DevULong64Class::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevULong64Class::execute(): arrived" << endl;
+	cout2 << "DevULong64Class::execute(): arrived" << std::endl;
 	Tango::DevULong64 argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_ulong64(argin));
@@ -380,7 +380,7 @@ CORBA::Any *DevULong64Class::execute(Tango::DeviceImpl *device, const CORBA::Any
 //--------------------------------------------------------
 CORBA::Any *DevUShortClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevUShortClass::execute(): arrived" << endl;
+	cout2 << "DevUShortClass::execute(): arrived" << std::endl;
 	Tango::DevUShort argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_ushort(argin));
@@ -399,7 +399,7 @@ CORBA::Any *DevUShortClass::execute(Tango::DeviceImpl *device, const CORBA::Any 
 //--------------------------------------------------------
 CORBA::Any *DevVarCharArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarCharArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarCharArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarCharArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_char_array(argin));
@@ -418,7 +418,7 @@ CORBA::Any *DevVarCharArrayClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DevVarDoubleArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarDoubleArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarDoubleArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarDoubleArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_double_array(argin));
@@ -437,7 +437,7 @@ CORBA::Any *DevVarDoubleArrayClass::execute(Tango::DeviceImpl *device, const COR
 //--------------------------------------------------------
 CORBA::Any *DevVarDoubleStringArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarDoubleStringArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarDoubleStringArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarDoubleStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_double_string_array(argin));
@@ -456,7 +456,7 @@ CORBA::Any *DevVarDoubleStringArrayClass::execute(Tango::DeviceImpl *device, con
 //--------------------------------------------------------
 CORBA::Any *DevVarFloatArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarFloatArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarFloatArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarFloatArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_float_array(argin));
@@ -475,7 +475,7 @@ CORBA::Any *DevVarFloatArrayClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DevVarLong64ArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarLong64ArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarLong64ArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarLong64Array *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_long64_array(argin));
@@ -494,7 +494,7 @@ CORBA::Any *DevVarLong64ArrayClass::execute(Tango::DeviceImpl *device, const COR
 //--------------------------------------------------------
 CORBA::Any *DevVarLongArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarLongArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarLongArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarLongArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_long_array(argin));
@@ -513,7 +513,7 @@ CORBA::Any *DevVarLongArrayClass::execute(Tango::DeviceImpl *device, const CORBA
 //--------------------------------------------------------
 CORBA::Any *DevVarLongStringArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarLongStringArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarLongStringArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarLongStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_long_string_array(argin));
@@ -532,7 +532,7 @@ CORBA::Any *DevVarLongStringArrayClass::execute(Tango::DeviceImpl *device, const
 //--------------------------------------------------------
 CORBA::Any *DevVarShortArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarShortArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarShortArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarShortArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_short_array(argin));
@@ -551,7 +551,7 @@ CORBA::Any *DevVarShortArrayClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DevVarStringArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarStringArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarStringArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarStringArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_string_array(argin));
@@ -570,7 +570,7 @@ CORBA::Any *DevVarStringArrayClass::execute(Tango::DeviceImpl *device, const COR
 //--------------------------------------------------------
 CORBA::Any *DevVarULong64ArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarULong64ArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarULong64ArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarULong64Array *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_ulong64_array(argin));
@@ -589,7 +589,7 @@ CORBA::Any *DevVarULong64ArrayClass::execute(Tango::DeviceImpl *device, const CO
 //--------------------------------------------------------
 CORBA::Any *DevVarULongArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarULongArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarULongArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarULongArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_ulong_array(argin));
@@ -608,7 +608,7 @@ CORBA::Any *DevVarULongArrayClass::execute(Tango::DeviceImpl *device, const CORB
 //--------------------------------------------------------
 CORBA::Any *DevVarUShortArrayClass::execute(Tango::DeviceImpl *device, const CORBA::Any &in_any)
 {
-	cout2 << "DevVarUShortArrayClass::execute(): arrived" << endl;
+	cout2 << "DevVarUShortArrayClass::execute(): arrived" << std::endl;
 	const Tango::DevVarUShortArray *argin;
 	extract(in_any, argin);
 	return insert((static_cast<TangoTest *>(device))->dev_var_ushort_array(argin));
@@ -627,7 +627,7 @@ CORBA::Any *DevVarUShortArrayClass::execute(Tango::DeviceImpl *device, const COR
 //--------------------------------------------------------
 CORBA::Any *DevVoidClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "DevVoidClass::execute(): arrived" << endl;
+	cout2 << "DevVoidClass::execute(): arrived" << std::endl;
 	((static_cast<TangoTest *>(device))->dev_void());
 	return new CORBA::Any();
 }
@@ -645,7 +645,7 @@ CORBA::Any *DevVoidClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const 
 //--------------------------------------------------------
 CORBA::Any *DumpExecutionStateClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "DumpExecutionStateClass::execute(): arrived" << endl;
+	cout2 << "DumpExecutionStateClass::execute(): arrived" << std::endl;
 	((static_cast<TangoTest *>(device))->dump_execution_state());
 	return new CORBA::Any();
 }
@@ -663,7 +663,7 @@ CORBA::Any *DumpExecutionStateClass::execute(Tango::DeviceImpl *device, TANGO_UN
 //--------------------------------------------------------
 CORBA::Any *SwitchStatesClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(const CORBA::Any &in_any))
 {
-	cout2 << "SwitchStatesClass::execute(): arrived" << endl;
+	cout2 << "SwitchStatesClass::execute(): arrived" << std::endl;
 	((static_cast<TangoTest *>(device))->switch_states());
 	return new CORBA::Any();
 }
@@ -678,7 +678,7 @@ CORBA::Any *SwitchStatesClass::execute(Tango::DeviceImpl *device, TANGO_UNUSED(c
  *	Description : Get the class property for specified name.
  */
 //--------------------------------------------------------
-Tango::DbDatum TangoTestClass::get_class_property(string &prop_name)
+Tango::DbDatum TangoTestClass::get_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_prop.size() ; i++)
 		if (cl_prop[i].name == prop_name)
@@ -693,7 +693,7 @@ Tango::DbDatum TangoTestClass::get_class_property(string &prop_name)
  *	Description : Return the default value for device property.
  */
 //--------------------------------------------------------
-Tango::DbDatum TangoTestClass::get_default_device_property(string &prop_name)
+Tango::DbDatum TangoTestClass::get_default_device_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<dev_def_prop.size() ; i++)
 		if (dev_def_prop[i].name == prop_name)
@@ -708,7 +708,7 @@ Tango::DbDatum TangoTestClass::get_default_device_property(string &prop_name)
  *	Description : Return the default value for class property.
  */
 //--------------------------------------------------------
-Tango::DbDatum TangoTestClass::get_default_class_property(string &prop_name)
+Tango::DbDatum TangoTestClass::get_default_class_property(std::string &prop_name)
 {
 	for (unsigned int i=0 ; i<cl_def_prop.size() ; i++)
 		if (cl_def_prop[i].name == prop_name)
@@ -729,10 +729,10 @@ Tango::DbDatum TangoTestClass::get_default_class_property(string &prop_name)
 //--------------------------------------------------------
 void TangoTestClass::set_default_property()
 {
-	string	prop_name;
-	string	prop_desc;
-	string	prop_def;
-	vector<string>	vect_data;
+	std::string	prop_name;
+	std::string	prop_desc;
+	std::string	prop_def;
+	std::vector<std::string>	vect_data;
 
 	//	Set Default Class Properties
 
@@ -792,125 +792,27 @@ void TangoTestClass::write_class_property()
 		return;
 
 	Tango::DbData	data;
-	string	classname = get_name();
-	string	header;
-	string::size_type	start, end;
+	std::string	classname = get_name();
+	std::string	header;
+	std::string::size_type	start, end;
 
 	//	Put title
 	Tango::DbDatum	title("ProjectTitle");
-	string	str_title("TANGO Device Server for testing generic clients");
+	std::string	str_title("TANGO Device Server for testing generic clients");
 	title << str_title;
 	data.push_back(title);
 
 	//	Put Description
 	Tango::DbDatum	description("Description");
-	vector<string>	str_desc;
+	std::vector<std::string>	str_desc;
 	str_desc.push_back("A device to test generic clients. It offers a \"echo\" like command for");
 	str_desc.push_back("each TANGO data type (i.e. each command returns an exact copy of <argin>).");
 	description << str_desc;
 	data.push_back(description);
 
-	//	put cvs or svn location
-	string	filename("TangoTest");
-	filename += "Class.cpp";
-
-	// check for cvs information
-	string	src_path(CvsPath);
-	start = src_path.find("/");
-	if (start!=string::npos)
-	{
-		end   = src_path.find(filename);
-		if (end>start)
-		{
-			string	strloc = src_path.substr(start, end-start);
-			//	Check if specific repository
-			start = strloc.find("/cvsroot/");
-			if (start!=string::npos && start>0)
-			{
-				string	repository = strloc.substr(0, start);
-				if (repository.find("/segfs/")!=string::npos)
-					strloc = "ESRF:" + strloc.substr(start, strloc.length()-start);
-			}
-			Tango::DbDatum	cvs_loc("cvs_location");
-			cvs_loc << strloc;
-			data.push_back(cvs_loc);
-		}
-	}
-
-	// check for svn information
-	else
-	{
-		string	src_path(SvnPath);
-		start = src_path.find("://");
-		if (start!=string::npos)
-		{
-			end = src_path.find(filename);
-			if (end>start)
-			{
-				header = "$HeadURL: ";
-				start = header.length();
-				string	strloc = src_path.substr(start, (end-start));
-				
-				Tango::DbDatum	svn_loc("svn_location");
-				svn_loc << strloc;
-				data.push_back(svn_loc);
-			}
-		}
-	}
-
-	//	Get CVS or SVN revision tag
-	
-	// CVS tag
-	string	tagname(TagName);
-	header = "$Name: ";
-	start = header.length();
-	string	endstr(" $");
-	
-	end   = tagname.find(endstr);
-	if (end!=string::npos && end>start)
-	{
-		string	strtag = tagname.substr(start, end-start);
-		Tango::DbDatum	cvs_tag("cvs_tag");
-		cvs_tag << strtag;
-		data.push_back(cvs_tag);
-	}
-	
-	// SVN tag
-	string	svnpath(SvnPath);
-	header = "$HeadURL: ";
-	start = header.length();
-	
-	end   = svnpath.find(endstr);
-	if (end!=string::npos && end>start)
-	{
-		string	strloc = svnpath.substr(start, end-start);
-		
-		string tagstr ("/tags/");
-		start = strloc.find(tagstr);
-		if ( start!=string::npos )
-		{
-			start = start + tagstr.length();
-			end   = strloc.find(filename);
-			string	strtag = strloc.substr(start, end-start-1);
-			
-			Tango::DbDatum	svn_tag("svn_tag");
-			svn_tag << strtag;
-			data.push_back(svn_tag);
-		}
-	}
-
-	//	Get URL location
-	string	httpServ(HttpServer);
-	if (httpServ.length()>0)
-	{
-		Tango::DbDatum	db_doc_url("doc_url");
-		db_doc_url << httpServ;
-		data.push_back(db_doc_url);
-	}
-
 	//  Put inheritance
 	Tango::DbDatum	inher_datum("InheritedFrom");
-	vector<string> inheritance;
+	std::vector<std::string> inheritance;
 	inheritance.push_back("TANGO_BASE_CLASS");
 	inher_datum << inheritance;
 	data.push_back(inher_datum);
@@ -941,7 +843,7 @@ void TangoTestClass::device_factory(const Tango::DevVarStringArray *devlist_ptr)
 	//	Create devices and add it into the device list
 	for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 	{
-		cout4 << "Device name : " << (*devlist_ptr)[i].in() << endl;
+		cout4 << "Device name : " << (*devlist_ptr)[i].in() << std::endl;
 		device_list.push_back(new TangoTest(this, (*devlist_ptr)[i]));
 	}
 
@@ -975,7 +877,7 @@ void TangoTestClass::device_factory(const Tango::DevVarStringArray *devlist_ptr)
  *                and store them in the attribute list
  */
 //--------------------------------------------------------
-void TangoTestClass::attribute_factory(vector<Tango::Attr *> &att_list)
+void TangoTestClass::attribute_factory(std::vector<Tango::Attr *> &att_list)
 {
 	/*----- PROTECTED REGION ID(TangoTestClass::attribute_factory_before) ENABLED START -----*/
 	
@@ -2736,16 +2638,16 @@ void TangoTestClass::command_factory()
  * @param	att_list	the ceated attribute list
  */
 //--------------------------------------------------------
-void TangoTestClass::create_static_attribute_list(vector<Tango::Attr *> &att_list)
+void TangoTestClass::create_static_attribute_list(std::vector<Tango::Attr *> &att_list)
 {
 	for (unsigned long i=0 ; i<att_list.size() ; i++)
 	{
-		string att_name(att_list[i]->get_name());
+		std::string att_name(att_list[i]->get_name());
 		transform(att_name.begin(), att_name.end(), att_name.begin(), ::tolower);
 		defaultAttList.push_back(att_name);
 	}
 
-	cout2 << defaultAttList.size() << " attributes in default list" << endl;
+	cout2 << defaultAttList.size() << " attributes in default list" << std::endl;
 
 	/*----- PROTECTED REGION ID(TangoTestClass::create_static_att_list) ENABLED START -----*/
 	
@@ -2762,26 +2664,26 @@ void TangoTestClass::create_static_attribute_list(vector<Tango::Attr *> &att_lis
  * @param	list of all attributes
  */
 //--------------------------------------------------------
-void TangoTestClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, vector<Tango::Attr *> &att_list)
+void TangoTestClass::erase_dynamic_attributes(const Tango::DevVarStringArray *devlist_ptr, std::vector<Tango::Attr *> &att_list)
 {
 	Tango::Util *tg = Tango::Util::instance();
 
 	for (unsigned long i=0 ; i<devlist_ptr->length() ; i++)
 	{
-		Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((string)(*devlist_ptr)[i]).c_str());
+		Tango::DeviceImpl *dev_impl = tg->get_device_by_name(((std::string)(*devlist_ptr)[i]).c_str());
 		TangoTest *dev = static_cast<TangoTest *> (dev_impl);
 
-		vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
-		vector<Tango::Attribute *>::iterator ite_att;
+		std::vector<Tango::Attribute *> &dev_att_list = dev->get_device_attr()->get_attribute_list();
+		std::vector<Tango::Attribute *>::iterator ite_att;
 		for (ite_att=dev_att_list.begin() ; ite_att != dev_att_list.end() ; ++ite_att)
 		{
-			string att_name((*ite_att)->get_name_lower());
+			std::string att_name((*ite_att)->get_name_lower());
 			if ((att_name == "state") || (att_name == "status"))
 				continue;
-			vector<string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
+			std::vector<std::string>::iterator ite_str = find(defaultAttList.begin(), defaultAttList.end(), att_name);
 			if (ite_str == defaultAttList.end())
 			{
-				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << endl;
+				cout2 << att_name << " is a UNWANTED dynamic attribute for device " << (*devlist_ptr)[i] << std::endl;
 				Tango::Attribute &att = dev->get_device_attr()->get_attr_by_name(att_name.c_str());
 				dev->remove_attribute(att_list[att.get_attr_idx()], true, false);
 				--ite_att;
@@ -2795,13 +2697,13 @@ void TangoTestClass::erase_dynamic_attributes(const Tango::DevVarStringArray *de
 
 //--------------------------------------------------------
 /**
- *	Method      : TangoTestClass::get_attr_by_name()
+ *	Method      : TangoTestClass::get_attr_object_by_name()
  *	Description : returns Tango::Attr * object found by name
  */
 //--------------------------------------------------------
-Tango::Attr *TangoTestClass::get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname)
+Tango::Attr *TangoTestClass::get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname)
 {
-	vector<Tango::Attr *>::iterator it;
+	std::vector<Tango::Attr *>::iterator it;
 	for (it=att_list.begin() ; it<att_list.end() ; ++it)
 		if ((*it)->get_name()==attname)
 			return (*it);

--- a/TangoTestClass.h
+++ b/TangoTestClass.h
@@ -906,7 +906,7 @@ public:
 class string_long_short_roClass: public Tango::Pipe
 {
 public:
-	string_long_short_roClass(const string &name, Tango::DispLevel level)
+	string_long_short_roClass(const std::string &name, Tango::DispLevel level)
 		:Pipe(name, level) {};
 
 	~string_long_short_roClass() {};
@@ -1568,28 +1568,28 @@ class TangoTestClass : public Tango::DeviceClass
 		static TangoTestClass *init(const char *);
 		static TangoTestClass *instance();
 		~TangoTestClass();
-		Tango::DbDatum	get_class_property(string &);
-		Tango::DbDatum	get_default_device_property(string &);
-		Tango::DbDatum	get_default_class_property(string &);
+		Tango::DbDatum	get_class_property(std::string &);
+		Tango::DbDatum	get_default_device_property(std::string &);
+		Tango::DbDatum	get_default_class_property(std::string &);
 	
 	protected:
-		TangoTestClass(string &);
+		TangoTestClass(std::string &);
 		static TangoTestClass *_instance;
 		void command_factory();
-		void attribute_factory(vector<Tango::Attr *> &);
+		void attribute_factory(std::vector<Tango::Attr *> &);
 		void pipe_factory();
 		void write_class_property();
 		void set_default_property();
 		void get_class_property();
-		string get_cvstag();
-		string get_cvsroot();
+		std::string get_cvstag();
+		std::string get_cvsroot();
 	
 	private:
 		void device_factory(const Tango::DevVarStringArray *);
-		void create_static_attribute_list(vector<Tango::Attr *> &);
-		void erase_dynamic_attributes(const Tango::DevVarStringArray *,vector<Tango::Attr *> &);
-		vector<string>	defaultAttList;
-		Tango::Attr *get_attr_object_by_name(vector<Tango::Attr *> &att_list, string attname);
+		void create_static_attribute_list(std::vector<Tango::Attr *> &);
+		void erase_dynamic_attributes(const Tango::DevVarStringArray *,std::vector<Tango::Attr *> &);
+		std::vector<std::string>	defaultAttList;
+		Tango::Attr *get_attr_object_by_name(std::vector<Tango::Attr *> &att_list, std::string attname);
 };
 
 }	//	End of namespace

--- a/TangoTestStateMachine.cpp
+++ b/TangoTestStateMachine.cpp
@@ -1147,7 +1147,7 @@ bool TangoTest::is_string_long_short_ro_allowed(TANGO_UNUSED(Tango::PipeReqType 
 	/*----- PROTECTED REGION ID(TangoTest::string_long_short_roStateAllowed_READ) ENABLED START -----*/
 	
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::string_long_short_roStateAllowed_READ
-    return true;
+	return true;
 }
 
 //=================================================
@@ -1558,5 +1558,12 @@ bool TangoTest::is_SwitchStates_allowed(TANGO_UNUSED(const CORBA::Any &any))
 	/*----- PROTECTED REGION END -----*/	//	TangoTest::SwitchStatesStateAllowed
 	return true;
 }
+
+
+/*----- PROTECTED REGION ID(TangoTest::TangoTestStateAllowed.AdditionalMethods) ENABLED START -----*/
+
+//	Additional Methods
+
+/*----- PROTECTED REGION END -----*/	//	TangoTest::TangoTestStateAllowed.AdditionalMethods
 
 }	//	End of namespace

--- a/main.cpp
+++ b/main.cpp
@@ -69,26 +69,26 @@ int main(int argc, char *argv[])
 
 		// Run the endless loop
 		//----------------------------------------
-		cout << "Ready to accept request" << endl;
+		cout << "Ready to accept request" << std::endl;
 
 		tg->server_run();
 	}
-	catch (bad_alloc)
+	catch (std::bad_alloc)
 	{
-		cout << "Can't allocate memory to store device object !!!" << endl;
-		cout << "Exiting" << endl;
+		cout << "Can't allocate memory to store device object !!!" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
 	catch (CORBA::Exception &e)
 	{
 		Tango::Except::print_exception(e);
 		
-		cout << "Received a CORBA_Exception" << endl;
-		cout << "Exiting" << endl;
+		cout << "Received a CORBA_Exception" << std::endl;
+		cout << "Exiting" << std::endl;
 	}
   catch (...)
   {
-		cout << "Received an unknown exception" << endl;
-		cout << "Exiting" << endl;
+		cout << "Received an unknown exception" << std::endl;
+		cout << "Exiting" << std::endl;
   }
 
 	tg->server_cleanup();


### PR DESCRIPTION
Hello,
I compiled cppTango on my Mac with `TANGO_USE_USING_NAMESPACE=OFF`.
To compile TangoTest, I had to replace:
- `endl` with `std::endl`
- `ends` with `std::ends`
- `string` with `std::string`
- `vector` with `std::vector`
- `bad_alloc` with `std::bad_alloc`

I think this is inline with what was done in cppTango: https://github.com/tango-controls/cppTango/pull/528